### PR TITLE
Update SDK to .NET 8 target net6.0 and net8.0, drop netcoreapp3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            6.0.x
             8.0.x
       - name: Build and Test
         run: dotnet test --logger "trx;LogFileName=test-results.trx"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
       NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - name: Get Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install .NET Core SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             3.1.x
@@ -32,7 +32,7 @@ jobs:
       - name: Build and Test
         run: dotnet test --logger "trx;LogFileName=test-results.trx"
       - name: Upload Test Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: test-results-${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.x
+            8.0.x
       - name: Build and Test
         run: dotnet test --logger "trx;LogFileName=test-results.trx"
       - name: Upload Test Results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        # libsass.dylib is not working on macos-14
+        os: [windows-latest, ubuntu-latest, macos-13]
     env:
       # https://github.com/NuGet/Home/issues/11548
       # https://twitter.com/xoofx/status/1488617114940452872?s=20&t=BKSN4j9rP6fOyg8l7aW0eg

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Process Test Results
         uses: dorny/test-reporter@v1

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # libsass.dylib is not working on macos-14
         os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Process Test Results

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724</WarningsNotAsErrors>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,24 @@
 <Project>
   <PropertyGroup>
+    <!--
+      Warnings that appeared with .NET 8.0.100
+      https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+      https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+      https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+      https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+      https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+      https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+      https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+      https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+      https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+      https://aka.ms/dotnet-warnings/SYSLIB0013
+      https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD103.md
+
+      CS0672 - Member 'ItemStream<TItem>.InitializeLifetimeService()' overrides obsolete member 'MarshalByRefObject.InitializeLifetimeService()'
+      SYSLIB0010: 'MarshalByRefObject.InitializeLifetimeService()' is obsolete: 'This Remoting API is not supported and throws PlatformNotSupportedException.'
+    -->
+    <NoWarn>CA1021;CA1040;CA1062;CA1505;CA1710;CA1711;CA1720;CA1721;CA1725;CS0672;SYSLIB0010;SYSLIB0013;VSTHRD103;$(NoWarn)</NoWarn>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <Version Condition="'$(StatiqFrameworkVersion)' == ''">1.0.0</Version>
     <Version Condition="'$(StatiqFrameworkVersion)' != ''">$(StatiqFrameworkVersion)</Version>
     <InformationalVersion>$(Version)</InformationalVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
       SYSLIB0010: 'MarshalByRefObject.InitializeLifetimeService()' is obsolete: 'This Remoting API is not supported and throws PlatformNotSupportedException.'
     -->
     <NoWarn>CA1021;CA1040;CA1062;CA1505;CA1710;CA1711;CA1720;CA1721;CA1725;CS0672;SYSLIB0010;SYSLIB0013;VSTHRD103;$(NoWarn)</NoWarn>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Version Condition="'$(StatiqFrameworkVersion)' == ''">1.0.0</Version>
     <Version Condition="'$(StatiqFrameworkVersion)' != ''">$(StatiqFrameworkVersion)</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
@@ -49,7 +49,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.0.2" PrivateAssets="All"/>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.6.2" PrivateAssets="All"/>
     <!-- It appears as though there might be a performance issue in versions of Microsoft.VisualStudio.Threading.Analyzers past this at least through 17.0.64 -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.9.60" PrivateAssets="All"/>
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,7 +47,7 @@
     <None Include="$(MSBuildThisFileDirectory)\icon.png" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
     <PackageReference Include="Roslynator.Analyzers" Version="4.0.2" PrivateAssets="All"/>
     <!-- It appears as though there might be a performance issue in versions of Microsoft.VisualStudio.Threading.Analyzers past this at least through 17.0.64 -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,7 +49,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.6.2" PrivateAssets="All"/>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.6.4" PrivateAssets="All"/>
     <!-- It appears as though there might be a performance issue in versions of Microsoft.VisualStudio.Threading.Analyzers past this at least through 17.0.64 -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.9.60" PrivateAssets="All"/>
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
       SYSLIB0010: 'MarshalByRefObject.InitializeLifetimeService()' is obsolete: 'This Remoting API is not supported and throws PlatformNotSupportedException.'
     -->
     <NoWarn>CA1021;CA1040;CA1062;CA1505;CA1710;CA1711;CA1720;CA1721;CA1725;CS0672;SYSLIB0010;SYSLIB0013;VSTHRD103;$(NoWarn)</NoWarn>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Version Condition="'$(StatiqFrameworkVersion)' == ''">1.0.0</Version>
     <Version Condition="'$(StatiqFrameworkVersion)' != ''">$(StatiqFrameworkVersion)</Version>
     <InformationalVersion>$(Version)</InformationalVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,7 +49,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.6.4" PrivateAssets="All"/>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1" PrivateAssets="All"/>
     <!-- It appears as though there might be a performance issue in versions of Microsoft.VisualStudio.Threading.Analyzers past this at least through 17.0.64 -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.9.60" PrivateAssets="All"/>
   </ItemGroup>

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -12,17 +12,28 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.18" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.45.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.18" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.18" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -16,17 +16,6 @@
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.45.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
   </ItemGroup>

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.13.0" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.45.0" />

--- a/src/core/Statiq.Common/Meta/TypeConversion/MetadataTypeConverter{T}.cs
+++ b/src/core/Statiq.Common/Meta/TypeConversion/MetadataTypeConverter{T}.cs
@@ -23,6 +23,10 @@ namespace Statiq.Common
         public static bool TryConvert(object value, out T result) =>
             UniversalTypeConverter.TryConvertTo(value, out result);
 
+        // This is where the magic happens via https://github.com/t-bruning/UniversalTypeConverter
+        public static bool TryConvertInvariant(object value, out T result) =>
+            UniversalTypeConverter.TryConvertTo(value, out result, System.Globalization.CultureInfo.InvariantCulture);
+
         private static IEnumerable<T> ConvertEnumerable(IEnumerable enumerable)
         {
             foreach (object value in enumerable)

--- a/src/core/Statiq.Common/Meta/TypeHelper.cs
+++ b/src/core/Statiq.Common/Meta/TypeHelper.cs
@@ -228,7 +228,7 @@ namespace Statiq.Common
             }
 
             // Check a normal conversion (in case it's a special type that implements a cast, IConvertible, or something)
-            if (MetadataTypeConverter<T>.TryConvert(value, out result))
+            if (MetadataTypeConverter<T>.TryConvertInvariant(value, out result))
             {
                 return true;
             }

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="NetFabric.Hyperlinq" Version="3.0.0-beta48" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   </ItemGroup>

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -7,15 +7,6 @@
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="ConcurrentHashSet" Version="1.1.0" />
     <PackageReference Include="NetFabric.Hyperlinq" Version="3.0.0-beta48" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -6,12 +6,21 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="ConcurrentHashSet" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.18" />
     <PackageReference Include="NetFabric.Hyperlinq" Version="3.0.0-beta48" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -18,7 +18,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="ConcurrentHashSet" Version="1.1.0" />
     <PackageReference Include="NetFabric.Hyperlinq" Version="3.0.0-beta48" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -8,13 +8,18 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.21.2" />
     <PackageReference Include="JSPool" Version="2.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Statiq.Common\Statiq.Common.csproj" />

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.21.0" />
     <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.21.2" />
     <PackageReference Include="JSPool" Version="2.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Polly" Version="7.1.1" />

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Statiq.Common\Statiq.Common.csproj" />

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.21.2" />
     <PackageReference Include="JSPool" Version="2.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -14,11 +14,6 @@
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-  </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.21.0" />
     <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.21.2" />
     <PackageReference Include="JSPool" Version="2.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="Shouldly" Version="4.2.1">
       <!-- See https://github.com/shouldly/shouldly/issues/795 -->
       <ExcludeAssets>build</ExcludeAssets>

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -11,7 +11,7 @@
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Statiq.Common\Statiq.Common.csproj" />

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="Shouldly" Version="4.0.3">
+    <PackageReference Include="Shouldly" Version="4.2.1">
       <!-- See https://github.com/shouldly/shouldly/issues/795 -->
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -10,7 +10,7 @@
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -4,14 +4,19 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Shouldly" Version="4.0.3">
       <!-- See https://github.com/shouldly/shouldly/issues/795 -->
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+  </ItemGroup>  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Statiq.Common\Statiq.Common.csproj" />

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="Shouldly" Version="4.0.3">
       <!-- See https://github.com/shouldly/shouldly/issues/795 -->
       <ExcludeAssets>build</ExcludeAssets>

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -10,11 +10,6 @@
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-  </ItemGroup>  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -9,7 +9,7 @@
       <!-- See https://github.com/shouldly/shouldly/issues/795 -->
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="Shouldly" Version="4.2.1">
       <!-- See https://github.com/shouldly/shouldly/issues/795 -->
       <ExcludeAssets>build</ExcludeAssets>

--- a/src/extensions/Statiq.Images/Statiq.Images.csproj
+++ b/src/extensions/Statiq.Images/Statiq.Images.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Images ImageProcessor</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />

--- a/src/extensions/Statiq.Images/Statiq.Images.csproj
+++ b/src/extensions/Statiq.Images/Statiq.Images.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Images ImageProcessor</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />

--- a/src/extensions/Statiq.Markdown/MarkdownHelper.cs
+++ b/src/extensions/Statiq.Markdown/MarkdownHelper.cs
@@ -112,7 +112,7 @@ namespace Statiq.Markdown
             }
             catch (Exception ex)
             {
-                document.LogWarning($"Exception while rendering Markdown: {ex.Message}");
+                document.LogWarning(ex, "Exception while rendering Markdown: {Message}", ex.Message);
             }
             return null;
         }

--- a/src/extensions/Statiq.Markdown/Statiq.Markdown.csproj
+++ b/src/extensions/Statiq.Markdown/Statiq.Markdown.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Markdown</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.31.0" />
+    <PackageReference Include="Markdig" Version="0.40.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.25" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.33" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -12,13 +12,13 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.33" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -7,7 +7,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.33" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.33" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
   </ItemGroup>

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -7,17 +7,18 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="3.1.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="3.1.15" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.25" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
   </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.25" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -10,14 +10,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.33" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.33" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.33" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.33" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
   </ItemGroup>

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -11,9 +11,16 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.15" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="3.1.15" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.18" />
+  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -7,10 +7,10 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.33" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.33" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.36" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.36" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.14" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.36" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.36" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.14" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />

--- a/src/extensions/Statiq.Razor/StatiqRazorProjectFileSystem.cs
+++ b/src/extensions/Statiq.Razor/StatiqRazorProjectFileSystem.cs
@@ -27,7 +27,6 @@ namespace Statiq.Razor
             _hostingEnvironment = hostingEnviroment.ThrowIfNull(nameof(hostingEnviroment));
         }
 
-        [Obsolete("Use GetItem(string path, string fileKind) instead.")]
         public override RazorProjectItem GetItem(string path)
         {
             return GetItem(path, fileKind: null);

--- a/src/extensions/Statiq.Xmp/Statiq.Xmp.csproj
+++ b/src/extensions/Statiq.Xmp/Statiq.Xmp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MetadataExtractor" Version="2.2.0" />
-    <PackageReference Include="SharpZipLib" Version="1.2.0" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="XmpCore" Version="6.1.10" />
   </ItemGroup>
   <ItemGroup>

--- a/src/extensions/Statiq.Yaml/Statiq.Yaml.csproj
+++ b/src/extensions/Statiq.Yaml/Statiq.Yaml.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Yaml</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="13.0.0" />
+    <PackageReference Include="YamlDotNet" Version="13.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,5 +7,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <HasRuntimeOutput>true</HasRuntimeOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <HasRuntimeOutput>true</HasRuntimeOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <HasRuntimeOutput>true</HasRuntimeOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <HasRuntimeOutput>true</HasRuntimeOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <HasRuntimeOutput>true</HasRuntimeOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/core/Statiq.App.Tests/Bootstrapper/BootstrapperFixture.cs
+++ b/tests/core/Statiq.App.Tests/Bootstrapper/BootstrapperFixture.cs
@@ -69,12 +69,12 @@ namespace Statiq.App.Tests.Bootstrapper
                 result.LogMessages.Count(x => x.FormattedMessage.StartsWith("Foo/Process")).ShouldBe(expected);
             }
 
-            [TestCase("Trace", false)]
-            [TestCase("Debug", false)]
-            [TestCase("Information", false)]
-            [TestCase("Warning", false)]
-            [TestCase("Error", true)]
-            [TestCase("Critical", true)]
+            [TestCase(LogLevel.Trace, false)]
+            [TestCase(LogLevel.Debug, false)]
+            [TestCase(LogLevel.Information, false)]
+            [TestCase(LogLevel.Warning, false)]
+            [TestCase(LogLevel.Error, true)]
+            [TestCase(LogLevel.Critical, true)]
             public async Task DefaultFailureLogLevel(LogLevel logLevel, bool expectedFailure)
             {
                 // Given
@@ -91,12 +91,12 @@ namespace Statiq.App.Tests.Bootstrapper
                 result.ExitCode.ShouldBe(expectedFailure ? (int)ExitCode.LogLevelFailure : (int)ExitCode.Normal);
             }
 
-            [TestCase("Trace", false)]
-            [TestCase("Debug", false)]
-            [TestCase("Information", false)]
-            [TestCase("Warning", true)]
-            [TestCase("Error", true)]
-            [TestCase("Critical", true)]
+            [TestCase(LogLevel.Trace, false)]
+            [TestCase(LogLevel.Debug, false)]
+            [TestCase(LogLevel.Information, false)]
+            [TestCase(LogLevel.Warning, true)]
+            [TestCase(LogLevel.Error, true)]
+            [TestCase(LogLevel.Critical, true)]
             public async Task SetFailureLogLevel(LogLevel logLevel, bool expectedFailure)
             {
                 // Given

--- a/tests/core/Statiq.Common.Tests/Documents/DocumentFixture.cs
+++ b/tests/core/Statiq.Common.Tests/Documents/DocumentFixture.cs
@@ -19,7 +19,7 @@ namespace Statiq.Common.Tests.Documents
                 Document b = new Document();
 
                 // Then
-                Assert.AreNotEqual(a.Id, b.Id);
+                Assert.That(b.Id, Is.Not.EqualTo(a.Id));
             }
 
             [Test]
@@ -48,7 +48,7 @@ namespace Statiq.Common.Tests.Documents
                 IDocument cloned = document.Clone(null);
 
                 // Then
-                Assert.AreEqual(document.Id, cloned.Id);
+                Assert.That(cloned.Id, Is.EqualTo(document.Id));
             }
 
             [Test]

--- a/tests/core/Statiq.Common.Tests/Documents/ObjectDocumentFixture.cs
+++ b/tests/core/Statiq.Common.Tests/Documents/ObjectDocumentFixture.cs
@@ -19,7 +19,7 @@ namespace Statiq.Common.Tests.Documents
                 IDocument b = new ObjectDocument<CustomObject>(obj);
 
                 // Then
-                Assert.AreNotEqual(a.Id, b.Id);
+                Assert.That(b.Id, Is.Not.EqualTo(a.Id));
             }
         }
 
@@ -36,7 +36,7 @@ namespace Statiq.Common.Tests.Documents
                 IDocument cloned = document.Clone(null);
 
                 // Then
-                Assert.AreEqual(document.Id, cloned.Id);
+                Assert.That(cloned.Id, Is.EqualTo(document.Id));
             }
 
             [Test]

--- a/tests/core/Statiq.Common.Tests/Documents/ToLookupExtensionsFixture.cs
+++ b/tests/core/Statiq.Common.Tests/Documents/ToLookupExtensionsFixture.cs
@@ -36,11 +36,14 @@ namespace Statiq.Common.Tests.Documents
                 ILookup<int, IDocument> lookup = documents.ToLookupMany<int>("Numbers");
 
                 // Then
-                Assert.AreEqual(4, lookup.Count);
-                CollectionAssert.AreEquivalent(new[] { a }, lookup[1]);
-                CollectionAssert.AreEquivalent(new[] { a, b }, lookup[2]);
-                CollectionAssert.AreEquivalent(new[] { a, b, c }, lookup[3]);
-                CollectionAssert.AreEquivalent(new[] { b, d }, lookup[4]);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(lookup, Has.Count.EqualTo(4));
+                    Assert.That(lookup[1], Is.EquivalentTo(new[] { a }));
+                    Assert.That(lookup[2], Is.EquivalentTo(new[] { a, b }));
+                    Assert.That(lookup[3], Is.EquivalentTo(new[] { a, b, c }));
+                    Assert.That(lookup[4], Is.EquivalentTo(new[] { b, d }));
+                });
             }
 
             [Test]
@@ -69,11 +72,14 @@ namespace Statiq.Common.Tests.Documents
                 ILookup<string, IDocument> lookup = documents.ToLookupMany<string>("Numbers");
 
                 // Then
-                Assert.AreEqual(4, lookup.Count);
-                CollectionAssert.AreEquivalent(new[] { a }, lookup["1"]);
-                CollectionAssert.AreEquivalent(new[] { a, b }, lookup["2"]);
-                CollectionAssert.AreEquivalent(new[] { a, b, c }, lookup["3"]);
-                CollectionAssert.AreEquivalent(new[] { b, d }, lookup["4"]);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(lookup, Has.Count.EqualTo(4));
+                    Assert.That(lookup["1"], Is.EquivalentTo(new[] { a }));
+                    Assert.That(lookup["2"], Is.EquivalentTo(new[] { a, b }));
+                    Assert.That(lookup["3"], Is.EquivalentTo(new[] { a, b, c }));
+                    Assert.That(lookup["4"], Is.EquivalentTo(new[] { b, d }));
+                });
             }
 
             [Test]
@@ -106,11 +112,14 @@ namespace Statiq.Common.Tests.Documents
                 ILookup<int, string> lookup = documents.ToLookupMany<int, string>("Numbers", "Colors");
 
                 // Then
-                Assert.AreEqual(4, lookup.Count);
-                CollectionAssert.AreEquivalent(new[] { "Red" }, lookup[1]);
-                CollectionAssert.AreEquivalent(new[] { "Red", "Red" }, lookup[2]);
-                CollectionAssert.AreEquivalent(new[] { "Red", "Red", "Green" }, lookup[3]);
-                CollectionAssert.AreEquivalent(new[] { "Red", "Green" }, lookup[4]);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(lookup, Has.Count.EqualTo(4));
+                    Assert.That(lookup[1], Is.EquivalentTo(new[] { "Red" }));
+                    Assert.That(lookup[2], Is.EquivalentTo(new[] { "Red", "Red" }));
+                    Assert.That(lookup[3], Is.EquivalentTo(new[] { "Red", "Red", "Green" }));
+                    Assert.That(lookup[4], Is.EquivalentTo(new[] { "Red", "Green" }));
+                });
             }
         }
 
@@ -146,11 +155,14 @@ namespace Statiq.Common.Tests.Documents
                 ILookup<int, string> lookup = documents.ToLookupManyToMany<int, string>("Numbers", "Colors");
 
                 // Then
-                Assert.AreEqual(4, lookup.Count);
-                CollectionAssert.AreEquivalent(new[] { "Red" }, lookup[1]);
-                CollectionAssert.AreEquivalent(new[] { "Red", "Red", "Blue" }, lookup[2]);
-                CollectionAssert.AreEquivalent(new[] { "Red", "Red", "Blue", "Green" }, lookup[3]);
-                CollectionAssert.AreEquivalent(new[] { "Red", "Blue", "Green", "Blue" }, lookup[4]);
+                Assert.That(lookup, Has.Count.EqualTo(4));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(lookup[1], Is.EquivalentTo(new[] { "Red" }));
+                    Assert.That(lookup[2], Is.EquivalentTo(new[] { "Red", "Red", "Blue" }));
+                    Assert.That(lookup[3], Is.EquivalentTo(new[] { "Red", "Red", "Blue", "Green" }));
+                    Assert.That(lookup[4], Is.EquivalentTo(new[] { "Red", "Blue", "Green", "Blue" }));
+                });
             }
         }
     }

--- a/tests/core/Statiq.Common.Tests/IO/Globbing/GlobberFixture.cs
+++ b/tests/core/Statiq.Common.Tests/IO/Globbing/GlobberFixture.cs
@@ -49,8 +49,8 @@ namespace Statiq.Common.Tests.IO.Globbing
                 IEnumerable<IFile> matchesReversedSlash = Globber.GetFiles(directory, patterns.Select(x => x.Replace("/", "\\")));
 
                 // Then
-                CollectionAssert.AreEquivalent(resultPaths, matches.Select(x => x.Path.FullPath));
-                CollectionAssert.AreEquivalent(resultPaths, matchesReversedSlash.Select(x => x.Path.FullPath));
+                Assert.That(matches.Select(x => x.Path.FullPath), Is.EquivalentTo(resultPaths));
+                Assert.That(matchesReversedSlash.Select(x => x.Path.FullPath), Is.EquivalentTo(resultPaths));
             }
 
             [Test]
@@ -110,8 +110,8 @@ namespace Statiq.Common.Tests.IO.Globbing
                 IEnumerable<IFile> matchesReversedSlash = Globber.GetFiles(directory, patterns.Select(x => x.Replace("/", "\\")));
 
                 // Then
-                CollectionAssert.AreEquivalent(resultPaths, matches.Select(x => x.Path.FullPath));
-                CollectionAssert.AreEquivalent(resultPaths, matchesReversedSlash.Select(x => x.Path.FullPath));
+                Assert.That(matches.Select(x => x.Path.FullPath), Is.EquivalentTo(resultPaths));
+                Assert.That(matchesReversedSlash.Select(x => x.Path.FullPath), Is.EquivalentTo(resultPaths));
             }
 
             // Addresses a specific problem with nested folders in a wildcard search
@@ -132,7 +132,7 @@ namespace Statiq.Common.Tests.IO.Globbing
                 IEnumerable<IFile> matches = Globber.GetFiles(directory, new[] { "**/*.txt" });
 
                 // Then
-                CollectionAssert.AreEquivalent(new[] { "/a/b/c/x.txt", "/a/bar/foo/y.txt" }, matches.Select(x => x.Path.FullPath));
+                Assert.That(matches.Select(x => x.Path.FullPath), Is.EquivalentTo(new[] { "/a/b/c/x.txt", "/a/bar/foo/y.txt" }));
             }
 
             [TestCase("/a/b")]
@@ -224,7 +224,7 @@ namespace Statiq.Common.Tests.IO.Globbing
                 IEnumerable<string> result = Globber.ExpandBraces(pattern);
 
                 // Then
-                CollectionAssert.AreEquivalent(expected, result);
+                Assert.That(result, Is.EquivalentTo(expected));
             }
         }
 

--- a/tests/core/Statiq.Common.Tests/IO/IReadOnlyFileSystemExtensionsFixture.cs
+++ b/tests/core/Statiq.Common.Tests/IO/IReadOnlyFileSystemExtensionsFixture.cs
@@ -32,7 +32,7 @@ namespace Statiq.Common.Tests.IO
                 IFile result = fileSystem.GetInputFile(input);
 
                 // Then
-                Assert.AreEqual(expected, result.Path.FullPath);
+                Assert.That(result.Path.FullPath, Is.EqualTo(expected));
             }
 
             [Test]
@@ -47,7 +47,7 @@ namespace Statiq.Common.Tests.IO
                 IFile result = fileSystem.GetInputFile("../bar.txt");
 
                 // Then
-                Assert.AreEqual("/a/x/bar.txt", result.Path.FullPath);
+                Assert.That(result.Path.FullPath, Is.EqualTo("/a/x/bar.txt"));
             }
 
             [Test]
@@ -62,7 +62,7 @@ namespace Statiq.Common.Tests.IO
                 IFile result = fileSystem.GetInputFile("bar.txt");
 
                 // Then
-                Assert.AreEqual("/a/x/bar.txt", result.Path.FullPath);
+                Assert.That(result.Path.FullPath, Is.EqualTo("/a/x/bar.txt"));
             }
 
             [Test]
@@ -77,7 +77,7 @@ namespace Statiq.Common.Tests.IO
                 IFile result = fileSystem.GetInputFile("../bar.txt");
 
                 // Then
-                Assert.AreEqual("/a/x/bar.txt", result.Path.FullPath);
+                Assert.That(result.Path.FullPath, Is.EqualTo("/a/x/bar.txt"));
             }
         }
 
@@ -93,8 +93,8 @@ namespace Statiq.Common.Tests.IO
                 IDirectory result = fileSystem.GetInputDirectory("A/B/C");
 
                 // Then
-                Assert.IsInstanceOf<VirtualInputDirectory>(result);
-                Assert.AreEqual("A/B/C", result.Path.FullPath);
+                Assert.That(result, Is.InstanceOf<VirtualInputDirectory>());
+                Assert.That(result.Path.FullPath, Is.EqualTo("A/B/C"));
             }
 
             [Test]
@@ -107,8 +107,8 @@ namespace Statiq.Common.Tests.IO
                 IDirectory result = fileSystem.GetInputDirectory("../A/B/C");
 
                 // Then
-                Assert.IsInstanceOf<VirtualInputDirectory>(result);
-                Assert.AreEqual("../A/B/C", result.Path.FullPath);
+                Assert.That(result, Is.InstanceOf<VirtualInputDirectory>());
+                Assert.That(result.Path.FullPath, Is.EqualTo("../A/B/C"));
             }
 
             [Test]
@@ -121,8 +121,8 @@ namespace Statiq.Common.Tests.IO
                 IDirectory result = fileSystem.GetInputDirectory();
 
                 // Then
-                Assert.IsInstanceOf<VirtualInputDirectory>(result);
-                Assert.AreEqual(string.Empty, result.Path.FullPath);
+                Assert.That(result, Is.InstanceOf<VirtualInputDirectory>());
+                Assert.That(result.Path.FullPath, Is.EqualTo(string.Empty));
             }
 
             [Test]
@@ -135,7 +135,7 @@ namespace Statiq.Common.Tests.IO
                 IDirectory result = fileSystem.GetInputDirectory("/A/B/C");
 
                 // Then
-                Assert.AreEqual("/A/B/C", result.Path.FullPath);
+                Assert.That(result.Path.FullPath, Is.EqualTo("/A/B/C"));
             }
         }
 
@@ -158,17 +158,18 @@ namespace Statiq.Common.Tests.IO
                 IEnumerable<IDirectory> result = fileSystem.GetInputDirectories();
 
                 // Then
-                CollectionAssert.AreEquivalent(
-                    new[]
-                {
-                    "/a/theme",
-                    "/a/input",
-                    "/a/b/c",
-                    "/a/b/d",
-                    "/a/x",
-                    "/a/y",
-                    "/z"
-                }, result.Select(x => x.Path.FullPath));
+                Assert.That(
+                    result.Select(x => x.Path.FullPath),
+                    Is.EquivalentTo(new[]
+                    {
+                        "/a/theme",
+                        "/a/input",
+                        "/a/b/c",
+                        "/a/b/d",
+                        "/a/x",
+                        "/a/y",
+                        "/z"
+                    }));
             }
         }
 
@@ -438,7 +439,7 @@ namespace Statiq.Common.Tests.IO
                 IEnumerable<IFile> results = fileSystem.GetFiles(dir, null, "**/foo.txt");
 
                 // Then
-                CollectionAssert.AreEquivalent(new[] { "/a/b/c/foo.txt" }, results.Select(x => x.Path.FullPath));
+                Assert.That(results.Select(x => x.Path.FullPath), Is.EquivalentTo(new[] { "/a/b/c/foo.txt" }));
             }
 
             [TestCase("/", new[] { "/a/b/c/foo.txt" }, new[] { "/a/b/c/foo.txt" }, true)]
@@ -486,7 +487,7 @@ namespace Statiq.Common.Tests.IO
                 IEnumerable<IFile> results = fileSystem.GetFiles(dir, patterns);
 
                 // Then
-                CollectionAssert.AreEquivalent(expected, results.Select(x => x.Path.FullPath));
+                Assert.That(results.Select(x => x.Path.FullPath), Is.EquivalentTo(expected));
 
                 if (reverseSlashes)
                 {
@@ -494,7 +495,7 @@ namespace Statiq.Common.Tests.IO
                     results = fileSystem.GetFiles(dir, patterns.Select(x => x.Replace("/", "\\")));
 
                     // Then
-                    CollectionAssert.AreEquivalent(expected, results.Select(x => x.Path.FullPath));
+                    Assert.That(results.Select(x => x.Path.FullPath), Is.EquivalentTo(expected));
                 }
             }
 
@@ -526,7 +527,7 @@ namespace Statiq.Common.Tests.IO
                 IEnumerable<IFile> results = fileSystem.GetFiles(dir, patterns);
 
                 // Then
-                CollectionAssert.AreEquivalent(expected, results.Select(x => x.Path.FullPath));
+                Assert.That(results.Select(x => x.Path.FullPath), Is.EquivalentTo(expected));
             }
         }
 

--- a/tests/core/Statiq.Common.Tests/IO/NormalizedPathFixture.cs
+++ b/tests/core/Statiq.Common.Tests/IO/NormalizedPathFixture.cs
@@ -591,7 +591,7 @@ namespace Statiq.Common.Tests.IO
                 NormalizedPath path = new NormalizedPath(fullPath);
 
                 // Then
-                Assert.AreEqual(expected, path.HasExtension);
+                Assert.That(path.HasExtension, Is.EqualTo(expected));
             }
         }
 
@@ -610,7 +610,7 @@ namespace Statiq.Common.Tests.IO
                 string extension = result.Extension;
 
                 // Then
-                Assert.AreEqual(expected, extension);
+                Assert.That(extension, Is.EqualTo(expected));
             }
         }
 
@@ -626,7 +626,7 @@ namespace Statiq.Common.Tests.IO
                 NormalizedPath directory = path.Parent;
 
                 // Then
-                Assert.AreEqual("temp", directory.FullPath);
+                Assert.That(directory.FullPath, Is.EqualTo("temp"));
             }
 
             [Test]
@@ -662,7 +662,7 @@ namespace Statiq.Common.Tests.IO
                 NormalizedPath rootRelative = path.RootRelative;
 
                 // Then
-                Assert.AreEqual(expected, rootRelative.FullPath);
+                Assert.That(rootRelative.FullPath, Is.EqualTo(expected));
             }
 
             [TestCase(@"\a\b\c")]
@@ -682,7 +682,7 @@ namespace Statiq.Common.Tests.IO
                 NormalizedPath rootRelative = path.RootRelative;
 
                 // Then
-                Assert.AreEqual(path.FullPath, rootRelative.FullPath);
+                Assert.That(rootRelative.FullPath, Is.EqualTo(path.FullPath));
             }
         }
 
@@ -711,7 +711,7 @@ namespace Statiq.Common.Tests.IO
                 normalized = normalized.ChangeExtension(extension);
 
                 // Then
-                Assert.AreEqual(expected, normalized.ToString());
+                Assert.That(normalized.ToString(), Is.EqualTo(expected));
             }
 
             [TestCase("foo")]
@@ -755,7 +755,7 @@ namespace Statiq.Common.Tests.IO
                 path = path.AppendExtension(extension);
 
                 // Then
-                Assert.AreEqual(expected, path.ToString());
+                Assert.That(path.ToString(), Is.EqualTo(expected));
             }
         }
 
@@ -787,7 +787,7 @@ namespace Statiq.Common.Tests.IO
                 filePath = filePath.InsertSuffix(suffix);
 
                 // Then
-                Assert.AreEqual(expected, filePath.FullPath);
+                Assert.That(filePath.FullPath, Is.EqualTo(expected));
             }
         }
 
@@ -820,7 +820,7 @@ namespace Statiq.Common.Tests.IO
                 filePath = filePath.InsertPrefix(prefix);
 
                 // Then
-                Assert.AreEqual(expected, filePath.FullPath);
+                Assert.That(filePath.FullPath, Is.EqualTo(expected));
             }
         }
 
@@ -985,7 +985,7 @@ namespace Statiq.Common.Tests.IO
                 string result = path.Name;
 
                 // Then
-                Assert.AreEqual(name, result);
+                Assert.That(result, Is.EqualTo(name));
             }
         }
 
@@ -1006,7 +1006,7 @@ namespace Statiq.Common.Tests.IO
                 NormalizedPath parent = path.Parent;
 
                 // Then
-                Assert.AreEqual(expected, parent.FullPath);
+                Assert.That(parent.FullPath, Is.EqualTo(expected));
             }
 
             [TestCase(".")]
@@ -1078,7 +1078,7 @@ namespace Statiq.Common.Tests.IO
                 NormalizedPath result = path.GetFilePath(new NormalizedPath(second));
 
                 // Then
-                Assert.AreEqual(expected, result.FullPath);
+                Assert.That(result.FullPath, Is.EqualTo(expected));
             }
         }
 
@@ -1121,7 +1121,7 @@ namespace Statiq.Common.Tests.IO
                 NormalizedPath result = path.Combine(new NormalizedPath(second));
 
                 // Then
-                Assert.AreEqual(expected, result.FullPath);
+                Assert.That(result.FullPath, Is.EqualTo(expected));
             }
         }
 

--- a/tests/core/Statiq.Common.Tests/IO/PathCollectionFixture.cs
+++ b/tests/core/Statiq.Common.Tests/IO/PathCollectionFixture.cs
@@ -49,7 +49,7 @@ namespace Statiq.Common.Tests.IO
                 PathCollection collection = new PathCollection(new[] { _upperCaseA, _upperCaseB });
 
                 // When, Then
-                Assert.AreEqual(2, collection.Count);
+                Assert.That(collection, Has.Count.EqualTo(2));
             }
         }
 
@@ -66,7 +66,7 @@ namespace Statiq.Common.Tests.IO
                 collection.Add(_upperCaseA);
 
                 // Then
-                Assert.AreEqual(2, collection.Count);
+                Assert.That(collection, Has.Count.EqualTo(2));
             }
         }
 
@@ -83,7 +83,7 @@ namespace Statiq.Common.Tests.IO
                 collection.AddRange(new[] { _upperCaseA, _upperCaseB, _upperCaseC });
 
                 // Then
-                Assert.AreEqual(3, collection.Count);
+                Assert.That(collection, Has.Count.EqualTo(3));
             }
         }
     }

--- a/tests/core/Statiq.Common.Tests/IO/VirtualInputDirectoryFixture.cs
+++ b/tests/core/Statiq.Common.Tests/IO/VirtualInputDirectoryFixture.cs
@@ -49,7 +49,7 @@ namespace Statiq.Common.Tests.IO
                 IEnumerable<IDirectory> directories = directory.GetDirectories(searchOption);
 
                 // Then
-                CollectionAssert.AreEquivalent(expectedPaths, directories.Select(x => x.Path.FullPath));
+                Assert.That(directories.Select(x => x.Path.FullPath), Is.EquivalentTo(expectedPaths));
             }
 
             [TestCase("a", SearchOption.AllDirectories, new[] { "a/b" })]
@@ -63,7 +63,7 @@ namespace Statiq.Common.Tests.IO
                 IEnumerable<IDirectory> directories = directory.GetDirectories(searchOption);
 
                 // Then
-                CollectionAssert.AreEquivalent(expectedPaths, directories.Select(x => x.Path.FullPath));
+                Assert.That(directories.Select(x => x.Path.FullPath), Is.EquivalentTo(expectedPaths));
             }
 
             [TestCase("", SearchOption.TopDirectoryOnly, new[] { "x", "i" })]
@@ -126,7 +126,7 @@ namespace Statiq.Common.Tests.IO
                 IEnumerable<IFile> files = directory.GetFiles(searchOption);
 
                 // Then
-                CollectionAssert.AreEquivalent(expectedPaths, files.Select(x => x.Path.FullPath));
+                Assert.That(files.Select(x => x.Path.FullPath), Is.EquivalentTo(expectedPaths));
             }
 
             [TestCase("", SearchOption.TopDirectoryOnly, new string[] { })]
@@ -173,8 +173,8 @@ namespace Statiq.Common.Tests.IO
                 IFile file = directory.GetFile(filePath);
 
                 // Then
-                Assert.AreEqual(expectedPath, file.Path.FullPath);
-                Assert.AreEqual(expectedExists, file.Exists);
+                Assert.That(file.Path.FullPath, Is.EqualTo(expectedPath));
+                Assert.That(file.Exists, Is.EqualTo(expectedExists));
             }
 
             [TestCase("", "x/y/z/foo.txt", "/root/a/x/y/z/foo.txt", true)]
@@ -203,8 +203,8 @@ namespace Statiq.Common.Tests.IO
                 IFile file = directory.GetFile(filePath);
 
                 // Then
-                Assert.AreEqual(expectedPath, file.Path.FullPath);
-                Assert.AreEqual(expectedExists, file.Exists);
+                Assert.That(file.Path.FullPath, Is.EqualTo(expectedPath));
+                Assert.That(file.Exists, Is.EqualTo(expectedExists));
             }
 
             [Test]
@@ -221,7 +221,7 @@ namespace Statiq.Common.Tests.IO
                 IFile file = directory.GetFile("../c/foo.txt");
 
                 // Then
-                Assert.AreEqual("/a/b/c/foo.txt", file.Path.FullPath);
+                Assert.That(file.Path.FullPath, Is.EqualTo("/a/b/c/foo.txt"));
             }
 
             [Test]
@@ -234,7 +234,7 @@ namespace Statiq.Common.Tests.IO
                 IFile file = directory.GetFile("../../z/fizz.txt");
 
                 // Then
-                Assert.AreEqual("/root/c/z/fizz.txt", file.Path.FullPath);
+                Assert.That(file.Path.FullPath, Is.EqualTo("/root/c/z/fizz.txt"));
             }
 
             [Test]
@@ -293,7 +293,7 @@ namespace Statiq.Common.Tests.IO
                 IDirectory result = directory.GetDirectory(path);
 
                 // Then
-                Assert.AreEqual(expected, result.Path.FullPath);
+                Assert.That(result.Path.FullPath, Is.EqualTo(expected));
             }
 
             [Test]
@@ -333,7 +333,7 @@ namespace Statiq.Common.Tests.IO
                 IDirectory result = directory.Parent;
 
                 // Then
-                Assert.AreEqual(expected, result?.Path.FullPath);
+                Assert.That(result?.Path.FullPath, Is.EqualTo(expected));
             }
         }
 

--- a/tests/core/Statiq.Common.Tests/Meta/MetadataFixture.cs
+++ b/tests/core/Statiq.Common.Tests/Meta/MetadataFixture.cs
@@ -60,7 +60,7 @@ namespace Statiq.Common.Tests.Meta
                 object value = metadata["A"];
 
                 // Then
-                Assert.AreEqual("a", value);
+                Assert.That(value, Is.EqualTo("a"));
             }
 
             [Test]
@@ -77,7 +77,7 @@ namespace Statiq.Common.Tests.Meta
                 object value = metadata["a"];
 
                 // Then
-                Assert.AreEqual("a", value);
+                Assert.That(value, Is.EqualTo("a"));
             }
         }
 
@@ -94,7 +94,7 @@ namespace Statiq.Common.Tests.Meta
                 bool contains = metadata.ContainsKey("A");
 
                 // Then
-                Assert.IsTrue(contains);
+                Assert.That(contains, Is.True);
             }
 
             [Test]
@@ -108,7 +108,7 @@ namespace Statiq.Common.Tests.Meta
                 bool contains = metadata.ContainsKey("B");
 
                 // Then
-                Assert.IsFalse(contains);
+                Assert.That(contains, Is.False);
             }
 
             [Test]
@@ -122,7 +122,7 @@ namespace Statiq.Common.Tests.Meta
                 bool contains = metadata.ContainsKey("a");
 
                 // Then
-                Assert.IsTrue(contains);
+                Assert.That(contains, Is.True);
             }
         }
 
@@ -140,8 +140,8 @@ namespace Statiq.Common.Tests.Meta
                 bool contains = metadata.TryGetValue("A", out value);
 
                 // Then
-                Assert.IsTrue(contains);
-                Assert.AreEqual("a", value);
+                Assert.That(contains, Is.True);
+                Assert.That(value, Is.EqualTo("a"));
             }
 
             [Test]
@@ -156,8 +156,11 @@ namespace Statiq.Common.Tests.Meta
                 bool contains = metadata.TryGetValue("B", out value);
 
                 // Then
-                Assert.IsFalse(contains);
-                Assert.AreEqual(null, value);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(contains, Is.False);
+                    Assert.That(value, Is.EqualTo(null));
+                });
             }
 
             [Test]
@@ -175,8 +178,11 @@ namespace Statiq.Common.Tests.Meta
                 bool contains = metadata.TryGetValue("A", out value);
 
                 // Then
-                Assert.IsTrue(contains);
-                Assert.AreEqual("a", value);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(contains, Is.True);
+                    Assert.That(value, Is.EqualTo("a"));
+                });
             }
         }
 
@@ -193,7 +199,7 @@ namespace Statiq.Common.Tests.Meta
                 metadata = new Metadata(metadata, new[] { new KeyValuePair<string, object>("A", "a") });
 
                 // Then
-                Assert.AreEqual("a", metadata["A"]);
+                Assert.That(metadata["A"], Is.EqualTo("a"));
             }
 
             [Test]
@@ -207,7 +213,7 @@ namespace Statiq.Common.Tests.Meta
                 Metadata clone = new Metadata(metadata, new Dictionary<string, object> { { "B", "b" } });
 
                 // Then
-                Assert.AreEqual("a", clone["A"]);
+                Assert.That(clone["A"], Is.EqualTo("a"));
             }
 
             [Test]
@@ -221,7 +227,7 @@ namespace Statiq.Common.Tests.Meta
                 Metadata clone = new Metadata(metadata, new Dictionary<string, object> { { "B", "b" } });
 
                 // Then
-                Assert.IsFalse(metadata.ContainsKey("B"));
+                Assert.That(metadata.ContainsKey("B"), Is.False);
             }
 
             [Test]
@@ -235,7 +241,7 @@ namespace Statiq.Common.Tests.Meta
                 Metadata clone = new Metadata(metadata, new Dictionary<string, object> { { "B", "b" } });
 
                 // Then
-                Assert.AreEqual("b", clone["B"]);
+                Assert.That(clone["B"], Is.EqualTo("b"));
             }
 
             [Test]
@@ -249,8 +255,11 @@ namespace Statiq.Common.Tests.Meta
                 Metadata clone = new Metadata(metadata, new Dictionary<string, object> { { "A", "b" } });
 
                 // Then
-                Assert.AreEqual("a", metadata["A"]);
-                Assert.AreEqual("b", clone["A"]);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(metadata["A"], Is.EqualTo("a"));
+                    Assert.That(clone["A"], Is.EqualTo("b"));
+                });
             }
         }
 
@@ -267,7 +276,7 @@ namespace Statiq.Common.Tests.Meta
                 object value = metadata.Get("A");
 
                 // Then
-                Assert.AreEqual("a", value);
+                Assert.That(value, Is.EqualTo("a"));
             }
 
             [Test]
@@ -285,7 +294,7 @@ namespace Statiq.Common.Tests.Meta
                 object value = metadata.Get("A");
 
                 // Then
-                Assert.AreEqual("x", value);
+                Assert.That(value, Is.EqualTo("x"));
             }
 
             [Test]
@@ -302,8 +311,11 @@ namespace Statiq.Common.Tests.Meta
                 value = metadata.Get("A");
 
                 // Then
-                Assert.AreEqual("a", value);
-                Assert.AreEqual(3, metadataValue.Calls);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(value, Is.EqualTo("a"));
+                    Assert.That(metadataValue.Calls, Is.EqualTo(3));
+                });
             }
         }
 
@@ -320,8 +332,11 @@ namespace Statiq.Common.Tests.Meta
                 IReadOnlyList<int> result = metadata.GetList<int>("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.AreEqual(result, new[] { 1, 2, 3 });
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(new[] { 1, 2, 3 }, Is.EqualTo(result).AsCollection);
+                });
             }
 
             [Test]
@@ -335,8 +350,8 @@ namespace Statiq.Common.Tests.Meta
                 IReadOnlyList<int> result = metadata.GetList<int>("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.AreEqual(result, new[] { 1, 2, 3 });
+                Assert.That(result, Is.Not.Null);
+                Assert.That(new[] { 1, 2, 3 }, Is.EqualTo(result).AsCollection);
             }
 
             [Test]
@@ -350,8 +365,8 @@ namespace Statiq.Common.Tests.Meta
                 IReadOnlyList<string> result = metadata.GetList<string>("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.AreEqual(result, new[] { "1", "2", "3" });
+                Assert.That(result, Is.Not.Null);
+                Assert.That(new[] { "1", "2", "3" }, Is.EqualTo(result).AsCollection);
             }
 
             [Test]
@@ -365,8 +380,8 @@ namespace Statiq.Common.Tests.Meta
                 IReadOnlyList<int> result = metadata.GetList<int>("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.AreEqual(result, new[] { 1, 2, 3 });
+                Assert.That(result, Is.Not.Null);
+                Assert.That(new[] { 1, 2, 3 }, Is.EqualTo(result).AsCollection);
             }
         }
 
@@ -400,8 +415,8 @@ namespace Statiq.Common.Tests.Meta
                 IEnumerable<IDocument> result = metadata.GetDocuments("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.AreEqual(new[] { a, b, c }, result);
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result, Is.EqualTo(new[] { a, b, c }).AsCollection);
             }
 
             [Test]
@@ -415,8 +430,8 @@ namespace Statiq.Common.Tests.Meta
                 IEnumerable<IDocument> result = metadata.GetDocuments("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.IsEmpty(result);
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result, Is.Empty);
             }
 
             [Test]
@@ -430,8 +445,8 @@ namespace Statiq.Common.Tests.Meta
                 IEnumerable<IDocument> result = metadata.GetDocuments("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.IsEmpty(result);
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result, Is.Empty);
             }
         }
 
@@ -448,7 +463,7 @@ namespace Statiq.Common.Tests.Meta
                 DocumentList<IDocument> result = metadata.GetDocumentList("A");
 
                 // Then
-                Assert.IsEmpty(result);
+                Assert.That(result, Is.Empty);
             }
 
             [Test]
@@ -465,8 +480,8 @@ namespace Statiq.Common.Tests.Meta
                 DocumentList<IDocument> result = metadata.GetDocumentList("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.AreEqual(new[] { a, b, c }, result);
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result, Is.EqualTo(new[] { a, b, c }).AsCollection);
             }
 
             [Test]
@@ -480,8 +495,8 @@ namespace Statiq.Common.Tests.Meta
                 DocumentList<IDocument> result = metadata.GetDocumentList("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.IsEmpty(result);
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result, Is.Empty);
             }
 
             [Test]
@@ -495,8 +510,8 @@ namespace Statiq.Common.Tests.Meta
                 DocumentList<IDocument> result = metadata.GetDocumentList("A");
 
                 // Then
-                Assert.IsNotNull(result);
-                CollectionAssert.IsEmpty(result);
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result, Is.Empty);
             }
         }
 
@@ -515,8 +530,8 @@ namespace Statiq.Common.Tests.Meta
                 object result = metadata.GetString("A");
 
                 // Then
-                Assert.IsInstanceOf<string>(result);
-                Assert.AreEqual(expected, result);
+                Assert.That(result, Is.InstanceOf<string>());
+                Assert.That(result, Is.EqualTo(expected));
             }
 
             [TestCase("/a/b/c", "/a/b/c")]
@@ -532,8 +547,8 @@ namespace Statiq.Common.Tests.Meta
                 object result = metadata.GetString("A");
 
                 // Then
-                Assert.IsInstanceOf<string>(result);
-                Assert.AreEqual(expected, result);
+                Assert.That(result, Is.InstanceOf<string>());
+                Assert.That(result, Is.EqualTo(expected));
             }
         }
 
@@ -638,7 +653,7 @@ namespace Statiq.Common.Tests.Meta
                 object[] values = metadata.Select(x => x.Value).ToArray();
 
                 // Then
-                CollectionAssert.AreEquivalent(new[] { "a", "b", "c" }, values);
+                Assert.That(values, Is.EquivalentTo(new[] { "a", "b", "c" }));
             }
         }
 

--- a/tests/core/Statiq.Common.Tests/Modules/ModuleListFixture.cs
+++ b/tests/core/Statiq.Common.Tests/Modules/ModuleListFixture.cs
@@ -159,10 +159,13 @@ namespace Statiq.Common.Tests.Modules
                 collection.InsertAfterFirst<RedModule>(new CountModule("foo"));
 
                 // Then
-                Assert.AreEqual(collection[0].GetType(), typeof(RedModule));
-                Assert.AreEqual(collection[1].GetType(), typeof(CountModule));
-                Assert.AreEqual(collection[2].GetType(), typeof(RedModule));
-                Assert.AreEqual(collection[3].GetType(), typeof(GreenModule));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(typeof(RedModule), Is.EqualTo(collection[0].GetType()));
+                    Assert.That(typeof(CountModule), Is.EqualTo(collection[1].GetType()));
+                    Assert.That(typeof(RedModule), Is.EqualTo(collection[2].GetType()));
+                    Assert.That(typeof(GreenModule), Is.EqualTo(collection[3].GetType()));
+                });
             }
         }
 
@@ -181,10 +184,13 @@ namespace Statiq.Common.Tests.Modules
                 collection.InsertBeforeFirst<RedModule>(new CountModule("foo"));
 
                 // Then
-                Assert.AreEqual(collection[0].GetType(), typeof(CountModule));
-                Assert.AreEqual(collection[1].GetType(), typeof(RedModule));
-                Assert.AreEqual(collection[2].GetType(), typeof(RedModule));
-                Assert.AreEqual(collection[3].GetType(), typeof(GreenModule));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(typeof(CountModule), Is.EqualTo(collection[0].GetType()));
+                    Assert.That(typeof(RedModule), Is.EqualTo(collection[1].GetType()));
+                    Assert.That(typeof(RedModule), Is.EqualTo(collection[2].GetType()));
+                    Assert.That(typeof(GreenModule), Is.EqualTo(collection[3].GetType()));
+                });
             }
         }
 
@@ -203,10 +209,13 @@ namespace Statiq.Common.Tests.Modules
                 collection.InsertAfterLast<RedModule>(new CountModule("foo"));
 
                 // Then
-                Assert.AreEqual(collection[0].GetType(), typeof(RedModule));
-                Assert.AreEqual(collection[1].GetType(), typeof(RedModule));
-                Assert.AreEqual(collection[2].GetType(), typeof(CountModule));
-                Assert.AreEqual(collection[3].GetType(), typeof(GreenModule));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(typeof(RedModule), Is.EqualTo(collection[0].GetType()));
+                    Assert.That(typeof(RedModule), Is.EqualTo(collection[1].GetType()));
+                    Assert.That(typeof(CountModule), Is.EqualTo(collection[2].GetType()));
+                    Assert.That(typeof(GreenModule), Is.EqualTo(collection[3].GetType()));
+                });
             }
         }
 
@@ -225,10 +234,13 @@ namespace Statiq.Common.Tests.Modules
                 collection.InsertBeforeLast<RedModule>(new CountModule("foo"));
 
                 // Then
-                Assert.AreEqual(collection[0].GetType(), typeof(RedModule));
-                Assert.AreEqual(collection[1].GetType(), typeof(CountModule));
-                Assert.AreEqual(collection[2].GetType(), typeof(RedModule));
-                Assert.AreEqual(collection[3].GetType(), typeof(GreenModule));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(typeof(RedModule), Is.EqualTo(collection[0].GetType()));
+                    Assert.That(typeof(CountModule), Is.EqualTo(collection[1].GetType()));
+                    Assert.That(typeof(RedModule), Is.EqualTo(collection[2].GetType()));
+                    Assert.That(typeof(GreenModule), Is.EqualTo(collection[3].GetType()));
+                });
             }
         }
 
@@ -248,8 +260,11 @@ namespace Statiq.Common.Tests.Modules
                 collection.ReplaceFirst<CountModule>(new CountModule("replacedKey"));
 
                 // Then
-                Assert.AreEqual("replacedKey", ((CountModule)collection[1]).ValueKey);
-                Assert.AreEqual("mykey2", ((CountModule)collection[2]).ValueKey);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(((CountModule)collection[1]).ValueKey, Is.EqualTo("replacedKey"));
+                    Assert.That(((CountModule)collection[2]).ValueKey, Is.EqualTo("mykey2"));
+                });
             }
         }
 
@@ -269,8 +284,11 @@ namespace Statiq.Common.Tests.Modules
                 collection.ReplaceLast<CountModule>(new CountModule("replacedKey"));
 
                 // Then
-                Assert.AreEqual("mykey1", ((CountModule)collection[1]).ValueKey);
-                Assert.AreEqual("replacedKey", ((CountModule)collection[2]).ValueKey);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(((CountModule)collection[1]).ValueKey, Is.EqualTo("mykey1"));
+                    Assert.That(((CountModule)collection[2]).ValueKey, Is.EqualTo("replacedKey"));
+                });
             }
         }
 

--- a/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
+++ b/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
@@ -3,7 +3,7 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Common\Statiq.Common.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Core\Statiq.Core.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Scripting\" />

--- a/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
+++ b/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
@@ -3,11 +3,6 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Common\Statiq.Common.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Core\Statiq.Core.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
+++ b/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
@@ -4,8 +4,11 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Core\Statiq.Core.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Scripting\" />

--- a/tests/core/Statiq.Common.Tests/Util/RelativeUrlFixture.cs
+++ b/tests/core/Statiq.Common.Tests/Util/RelativeUrlFixture.cs
@@ -27,7 +27,7 @@ namespace Statiq.Common.Tests.Util
                 RelativeUrl relativeUrl = new RelativeUrl(url);
 
                 // Then
-                Assert.AreEqual(expected, relativeUrl.HasRoot);
+                Assert.That(relativeUrl.HasRoot, Is.EqualTo(expected));
             }
 
             [TestCase(null, "")]
@@ -55,7 +55,7 @@ namespace Statiq.Common.Tests.Util
                 RelativeUrl relativeUrl = new RelativeUrl(url);
 
                 // Then
-                Assert.AreEqual(expected, relativeUrl.Fragment);
+                Assert.That(relativeUrl.Fragment, Is.EqualTo(expected));
             }
 
             [TestCase(null, "")]
@@ -97,7 +97,7 @@ namespace Statiq.Common.Tests.Util
                 RelativeUrl relativeUrl = new RelativeUrl(url);
 
                 // Then
-                Assert.AreEqual(expected, relativeUrl.Query);
+                Assert.That(relativeUrl.Query, Is.EqualTo(expected));
             }
 
             [TestCase(null, null)]
@@ -135,7 +135,7 @@ namespace Statiq.Common.Tests.Util
                 RelativeUrl relativeUrl = new RelativeUrl(url);
 
                 // Then
-                Assert.AreEqual(expected, (string)relativeUrl.Path);
+                Assert.That((string)relativeUrl.Path, Is.EqualTo(expected));
             }
 
             [TestCase("?", null, "?")]
@@ -155,7 +155,7 @@ namespace Statiq.Common.Tests.Util
                 RelativeUrl relativeUrl = new RelativeUrl(url, root);
 
                 // Then
-                Assert.AreEqual(expected, relativeUrl.ToString());
+                Assert.That(relativeUrl.ToString(), Is.EqualTo(expected));
             }
 
             [Test]
@@ -165,7 +165,7 @@ namespace Statiq.Common.Tests.Util
                 RelativeUrl relativeUrl = new RelativeUrl("~/foo?a=b#fragment", "root");
 
                 // Then
-                Assert.AreEqual(relativeUrl.ToString(), (string)relativeUrl);
+                Assert.That((string)relativeUrl, Is.EqualTo(relativeUrl.ToString()));
             }
         }
     }

--- a/tests/core/Statiq.Core.Tests/Execution/PipelineCollectionFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Execution/PipelineCollectionFixture.cs
@@ -56,7 +56,7 @@ namespace Statiq.Core.Tests.Execution
                 bool contains = pipelines.ContainsKey("test");
 
                 // Then
-                Assert.IsTrue(contains);
+                Assert.That(contains, Is.True);
             }
         }
     }

--- a/tests/core/Statiq.Core.Tests/IO/FileSystemFixture.cs
+++ b/tests/core/Statiq.Core.Tests/IO/FileSystemFixture.cs
@@ -18,7 +18,7 @@ namespace Statiq.Core.Tests.IO
                 FileSystem fileSystem = new FileSystem();
 
                 // Then
-                CollectionAssert.AreEquivalent(new[] { "input" }, fileSystem.InputPaths.Select(x => x.FullPath));
+                Assert.That(fileSystem.InputPaths.Select(x => x.FullPath), Is.EquivalentTo(new[] { "input" }));
             }
         }
 
@@ -54,7 +54,7 @@ namespace Statiq.Core.Tests.IO
                 fileSystem.RootPath = "/foo/bar";
 
                 // Then
-                Assert.AreEqual("/foo/bar", fileSystem.RootPath.FullPath);
+                Assert.That(fileSystem.RootPath.FullPath, Is.EqualTo("/foo/bar"));
             }
         }
 
@@ -80,7 +80,7 @@ namespace Statiq.Core.Tests.IO
                 fileSystem.OutputPath = "/foo/bar";
 
                 // Then
-                Assert.AreEqual("/foo/bar", fileSystem.OutputPath.FullPath);
+                Assert.That(fileSystem.OutputPath.FullPath, Is.EqualTo("/foo/bar"));
             }
         }
 

--- a/tests/core/Statiq.Core.Tests/Modules/Control/CombineDocumentsFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/CombineDocumentsFixture.cs
@@ -26,12 +26,12 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(new[] { a, b }, combine);
 
                 // Then
-                CollectionAssert.AreEqual(
-                    new[] { "ab" },
+                Assert.That(
                     await results
                         .ToAsyncEnumerable()
                         .SelectAwait(async x => await x.GetContentStringAsync())
-                        .ToListAsync());
+                        .ToListAsync(),
+                    Is.EqualTo(new[] { "ab" }).AsCollection);
             }
 
             [Test]

--- a/tests/core/Statiq.Core.Tests/Modules/Control/ConcatDocumentsFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/ConcatDocumentsFixture.cs
@@ -36,16 +36,19 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(a, new ConcatDocuments(b), c);
 
                 // Then
-                Assert.AreEqual(1, a.ExecuteCount);
-                Assert.AreEqual(1, b.ExecuteCount);
-                Assert.AreEqual(1, c.ExecuteCount);
-                Assert.AreEqual(1, a.InputCount);
-                Assert.AreEqual(2, b.InputCount);
-                Assert.AreEqual(8, c.InputCount);
-                Assert.AreEqual(2, a.OutputCount);
-                Assert.AreEqual(6, b.OutputCount);
-                Assert.AreEqual(32, c.OutputCount);
-                results.Count.ShouldBe(32);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(a.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(b.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(c.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(a.InputCount, Is.EqualTo(1));
+                    Assert.That(b.InputCount, Is.EqualTo(2));
+                    Assert.That(c.InputCount, Is.EqualTo(8));
+                    Assert.That(a.OutputCount, Is.EqualTo(2));
+                    Assert.That(b.OutputCount, Is.EqualTo(6));
+                    Assert.That(c.OutputCount, Is.EqualTo(32));
+                    Assert.That(results, Has.Count.EqualTo(32));
+                });
             }
         }
     }

--- a/tests/core/Statiq.Core.Tests/Modules/Control/ExecuteSwitchFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/ExecuteSwitchFixture.cs
@@ -24,10 +24,13 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(a, switchModule);
 
                 // Then
-                Assert.AreEqual(1, a.ExecuteCount);
-                Assert.AreEqual(1, b.ExecuteCount);
-                Assert.AreEqual(1, c.ExecuteCount);
-                Assert.AreEqual(1, d.ExecuteCount);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(a.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(b.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(c.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(d.ExecuteCount, Is.EqualTo(1));
+                });
             }
 
             [Test]
@@ -47,11 +50,14 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(a, switchModule, c);
 
                 // Then
-                Assert.AreEqual(1, a.ExecuteCount);
-                Assert.AreEqual(1, b.ExecuteCount);
-                Assert.AreEqual(3, b.InputCount);
-                Assert.AreEqual(3, b.OutputCount);
-                Assert.AreEqual(3, c.InputCount);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(a.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(b.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(b.InputCount, Is.EqualTo(3));
+                    Assert.That(b.OutputCount, Is.EqualTo(3));
+                    Assert.That(c.InputCount, Is.EqualTo(3));
+                });
             }
 
             [Test]
@@ -71,11 +77,14 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(a, switchModule, c);
 
                 // Then
-                Assert.AreEqual(1, a.ExecuteCount);
-                Assert.AreEqual(1, b.ExecuteCount);
-                Assert.AreEqual(1, b.InputCount);
-                Assert.AreEqual(1, b.OutputCount);
-                Assert.AreEqual(3, c.InputCount);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(a.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(b.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(b.InputCount, Is.EqualTo(1));
+                    Assert.That(b.OutputCount, Is.EqualTo(1));
+                    Assert.That(c.InputCount, Is.EqualTo(3));
+                });
             }
 
             [Test]
@@ -95,11 +104,14 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(a, switchModule, c);
 
                 // Then
-                Assert.AreEqual(1, a.ExecuteCount);
-                Assert.AreEqual(1, b.ExecuteCount);
-                Assert.AreEqual(2, b.InputCount);
-                Assert.AreEqual(2, b.OutputCount);
-                Assert.AreEqual(3, c.InputCount);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(a.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(b.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(b.InputCount, Is.EqualTo(2));
+                    Assert.That(b.OutputCount, Is.EqualTo(2));
+                    Assert.That(c.InputCount, Is.EqualTo(3));
+                });
             }
 
             [Test]
@@ -118,7 +130,7 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(a, switchModule, b);
 
                 // Then
-                Assert.AreEqual(3, b.InputCount);
+                Assert.That(b.InputCount, Is.EqualTo(3));
             }
         }
     }

--- a/tests/core/Statiq.Core.Tests/Modules/Control/GroupDocumentsFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/GroupDocumentsFixture.cs
@@ -35,7 +35,7 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(count, groupByMany, gatherData);
 
                 // Then
-                CollectionAssert.AreEquivalent(new[] { 0, 1, 2, 3 }, groupKey);
+                Assert.That(groupKey, Is.EquivalentTo(new[] { 0, 1, 2, 3 }));
             }
 
             [Test]
@@ -66,11 +66,14 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(count, groupByMany, orderBy, gatherData);
 
                 // Then
-                Assert.AreEqual(4, content.Count);
-                CollectionAssert.AreEquivalent(new[] { "3", "6" }, content[0]);
-                CollectionAssert.AreEquivalent(new[] { "1", "4", "7" }, content[1]);
-                CollectionAssert.AreEquivalent(new[] { "2", "5", "8" }, content[2]);
-                CollectionAssert.AreEquivalent(new[] { "1", "2", "3", "4", "5", "6", "7", "8" }, content[3]);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(content, Has.Count.EqualTo(4));
+                    Assert.That(content[0], Is.EquivalentTo(new[] { "3", "6" }));
+                    Assert.That(content[1], Is.EquivalentTo(new[] { "1", "4", "7" }));
+                    Assert.That(content[2], Is.EquivalentTo(new[] { "2", "5", "8" }));
+                    Assert.That(content[3], Is.EquivalentTo(new[] { "1", "2", "3", "4", "5", "6", "7", "8" }));
+                });
             }
 
             [Test]
@@ -96,7 +99,7 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(count, meta, groupByMany, gatherData);
 
                 // Then
-                CollectionAssert.AreEquivalent(new[] { 0, 1, 2, 3 }, groupKey);
+                Assert.That(groupKey, Is.EquivalentTo(new[] { 0, 1, 2, 3 }));
             }
 
             [Test]
@@ -127,7 +130,7 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(count, meta, groupByMany, gatherData);
 
                 // Then
-                CollectionAssert.AreEquivalent(new[] { 1, 2, 3 }, groupKey);
+                Assert.That(groupKey, Is.EquivalentTo(new[] { 1, 2, 3 }));
             }
 
             [Test]
@@ -157,7 +160,7 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(meta, groupByMany, gatherData);
 
                 // Then
-                CollectionAssert.AreEquivalent(new object[] { "A", "B", "b", "C", "c", 1, "1" }, groupKey);
+                Assert.That(groupKey, Is.EquivalentTo(new object[] { "A", "B", "b", "C", "c", 1, "1" }));
             }
 
             [Test]
@@ -187,7 +190,7 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(meta, groupByMany, gatherData);
 
                 // Then
-                CollectionAssert.AreEquivalent(new object[] { "A", "b", "C", 1 }, groupKey);
+                Assert.That(groupKey, Is.EquivalentTo(new object[] { "A", "b", "C", 1 }));
             }
         }
     }

--- a/tests/core/Statiq.Core.Tests/Modules/Control/MergeDocumentsFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/MergeDocumentsFixture.cs
@@ -35,7 +35,7 @@ namespace Statiq.Core.Tests.Modules.Control
                     new SetMetadata("Content", Config.FromDocument(async doc => await doc.GetContentStringAsync())));
 
                 // Then
-                CollectionAssert.AreEqual(new[] { "1121" }, results.Select(x => x["Content"]));
+                Assert.That(results.Select(x => x["Content"]), Is.EqualTo(new[] { "1121" }).AsCollection);
             }
 
             [Test]
@@ -60,7 +60,7 @@ namespace Statiq.Core.Tests.Modules.Control
                     new SetMetadata("Content", Config.FromDocument(async doc => await doc.GetContentStringAsync())));
 
                 // Then
-                CollectionAssert.AreEqual(new[] { "11" }, results.Select(x => x["Content"]));
+                Assert.That(results.Select(x => x["Content"]), Is.EqualTo(new[] { "11" }).AsCollection);
             }
 
             [Test]
@@ -82,8 +82,11 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(a, new MergeDocuments(b));
 
                 // Then
-                CollectionAssert.AreEqual(new[] { 11 }, results.Select(x => x["A"]));
-                CollectionAssert.AreEqual(new[] { 21 }, results.Select(x => x["B"]));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(results.Select(x => x["A"]), Is.EqualTo(new[] { 11 }).AsCollection);
+                    Assert.That(results.Select(x => x["B"]), Is.EqualTo(new[] { 21 }).AsCollection);
+                });
             }
 
             [Test]
@@ -105,7 +108,7 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(a, new MergeDocuments(b));
 
                 // Then
-                CollectionAssert.AreEqual(new[] { 21 }, results.Select(x => x["A"]));
+                Assert.That(results.Select(x => x["A"]), Is.EqualTo(new[] { 21 }).AsCollection);
             }
 
             [Test]
@@ -127,10 +130,13 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(a, new MergeDocuments(b));
 
                 // Then
-                Assert.AreEqual(1, a.OutputCount);
-                Assert.AreEqual(1, b.OutputCount);
-                CollectionAssert.AreEqual(new[] { 11 }, results.Select(x => x["A"]));
-                CollectionAssert.AreEqual(new[] { 21 }, results.Select(x => x["B"]));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(a.OutputCount, Is.EqualTo(1));
+                    Assert.That(b.OutputCount, Is.EqualTo(1));
+                    Assert.That(results.Select(x => x["A"]), Is.EqualTo(new[] { 11 }).AsCollection);
+                    Assert.That(results.Select(x => x["B"]), Is.EqualTo(new[] { 21 }).AsCollection);
+                });
             }
 
             [Test]
@@ -152,11 +158,14 @@ namespace Statiq.Core.Tests.Modules.Control
                 // When
                 IReadOnlyList<IDocument> results = await ExecuteAsync(a, new MergeDocuments(b));
 
-                // Then
-                Assert.AreEqual(1, a.OutputCount);
-                Assert.AreEqual(2, b.OutputCount);
-                CollectionAssert.AreEqual(new[] { 11, 11 }, results.Select(x => x["A"]));
-                CollectionAssert.AreEqual(new[] { 21, 22 }, results.Select(x => x["B"]));
+                Assert.Multiple(() =>
+                {
+                    // Then
+                    Assert.That(a.OutputCount, Is.EqualTo(1));
+                    Assert.That(b.OutputCount, Is.EqualTo(2));
+                    Assert.That(results.Select(x => x["A"]), Is.EqualTo(new[] { 11, 11 }).AsCollection);
+                    Assert.That(results.Select(x => x["B"]), Is.EqualTo(new[] { 21, 22 }).AsCollection);
+                });
             }
 
             [Test]
@@ -236,15 +245,18 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<IDocument> results = await ExecuteAsync(a, new MergeDocuments(b), c);
 
                 // Then
-                Assert.AreEqual(1, a.ExecuteCount);
-                Assert.AreEqual(1, b.ExecuteCount);
-                Assert.AreEqual(1, c.ExecuteCount);
-                Assert.AreEqual(1, a.InputCount);
-                Assert.AreEqual(2, b.InputCount);
-                Assert.AreEqual(12, c.InputCount);
-                Assert.AreEqual(2, a.OutputCount);
-                Assert.AreEqual(6, b.OutputCount);
-                Assert.AreEqual(48, c.OutputCount);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(a.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(b.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(c.ExecuteCount, Is.EqualTo(1));
+                    Assert.That(a.InputCount, Is.EqualTo(1));
+                    Assert.That(b.InputCount, Is.EqualTo(2));
+                    Assert.That(c.InputCount, Is.EqualTo(12));
+                    Assert.That(a.OutputCount, Is.EqualTo(2));
+                    Assert.That(b.OutputCount, Is.EqualTo(6));
+                    Assert.That(c.OutputCount, Is.EqualTo(48));
+                });
                 results.Count.ShouldBe(48);
             }
         }

--- a/tests/core/Statiq.Core.Tests/Modules/Control/OrderDocumentsFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/OrderDocumentsFixture.cs
@@ -107,8 +107,8 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(count, count2, orderBy, gatherData);
 
                 // Then
-                Assert.AreEqual(10, content.Count); // (4+1) * (21+1)
-                CollectionAssert.AreEqual(new[] { "11", "12", "23", "24", "35", "36", "47", "48", "59", "510" }, content);
+                Assert.That(content, Has.Count.EqualTo(10)); // (4+1) * (21+1)
+                Assert.That(content, Is.EqualTo(new[] { "11", "12", "23", "24", "35", "36", "47", "48", "59", "510" }).AsCollection);
             }
 
             [Test]
@@ -139,8 +139,8 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(count, count2, orderBy, gatherData);
 
                 // Then
-                Assert.AreEqual(10, content.Count); // (4+1) * (21+1)
-                CollectionAssert.AreEqual(new[] { "12", "11", "24", "23", "36", "35", "48", "47", "510", "59" }, content);
+                Assert.That(content.Count, Is.EqualTo(10)); // (4+1) * (21+1)
+                Assert.That(content, Is.EqualTo(new[] { "12", "11", "24", "23", "36", "35", "48", "47", "510", "59" }).AsCollection);
             }
 
             [Test]
@@ -172,8 +172,8 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(count, count2, orderBy, gatherData);
 
                 // Then
-                Assert.AreEqual(10, content.Count); // (4+1) * (21+1)
-                CollectionAssert.AreEqual(new[] { "510", "59", "48", "47", "36", "35", "24", "23", "12", "11" }, content);
+                Assert.That(content, Has.Count.EqualTo(10)); // (4+1) * (21+1)
+                Assert.That(content, Is.EqualTo(new[] { "510", "59", "48", "47", "36", "35", "24", "23", "12", "11" }).AsCollection);
             }
 
             [Test]
@@ -204,8 +204,8 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(count, count2, orderBy, gatherData);
 
                 // Then
-                Assert.AreEqual(10, content.Count); // (4+1) * (21+1)
-                CollectionAssert.AreEqual(new[] { "59", "510", "47", "48", "35", "36", "23", "24", "11", "12" }, content);
+                Assert.That(content, Has.Count.EqualTo(10)); // (4+1) * (21+1)
+                Assert.That(content, Is.EqualTo(new[] { "59", "510", "47", "48", "35", "36", "23", "24", "11", "12" }).AsCollection);
             }
 
             [Test]

--- a/tests/core/Statiq.Core.Tests/Modules/Control/PaginateDocumentsFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/PaginateDocumentsFixture.cs
@@ -40,10 +40,13 @@ namespace Statiq.Core.Tests.Modules.Control
                 await ExecuteAsync(count, paginate, gatherData);
 
                 // Then
-                Assert.AreEqual(3, content.Count);
-                CollectionAssert.AreEqual(new[] { "1", "2", "3" }, content[0]);
-                CollectionAssert.AreEqual(new[] { "4", "5", "6" }, content[1]);
-                CollectionAssert.AreEqual(new[] { "7", "8" }, content[2]);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(content, Has.Count.EqualTo(3));
+                    Assert.That(content[0], Is.EqualTo(new[] { "1", "2", "3" }).AsCollection);
+                    Assert.That(content[1], Is.EqualTo(new[] { "4", "5", "6" }).AsCollection);
+                    Assert.That(content[2], Is.EqualTo(new[] { "7", "8" }).AsCollection);
+                });
             }
 
             [Test]

--- a/tests/core/Statiq.Core.Tests/Modules/Control/ProcessSidecarFileFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/ProcessSidecarFileFixture.cs
@@ -36,8 +36,11 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<TestDocument> documents = await ExecuteAsync(inputs, context, sidecar);
 
                 // Then
-                Assert.AreEqual("data: a1", lodedSidecarContent);
-                Assert.AreEqual("File a1", documents.Single().Content);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(lodedSidecarContent, Is.EqualTo("data: a1"));
+                    Assert.That(documents.Single().Content, Is.EqualTo("File a1"));
+                });
             }
 
             [Test]
@@ -63,8 +66,11 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<TestDocument> documents = await ExecuteAsync(inputs, context, sidecar);
 
                 // Then
-                Assert.AreEqual("data: other", lodedSidecarContent);
-                Assert.AreEqual("File a1", documents.Single().Content);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(lodedSidecarContent, Is.EqualTo("data: other"));
+                    Assert.That(documents.Single().Content, Is.EqualTo("File a1"));
+                });
             }
 
             [Test]
@@ -90,8 +96,11 @@ namespace Statiq.Core.Tests.Modules.Control
                 IReadOnlyList<TestDocument> documents = await ExecuteAsync(inputs, context, sidecar);
 
                 // Then
-                Assert.IsFalse(executedSidecarModules);
-                Assert.AreEqual(inputs.First(), documents.First());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(executedSidecarModules, Is.False);
+                    Assert.That(documents.First(), Is.EqualTo(inputs.First()));
+                });
             }
 
             private TestDocument GetDocument(string source, string content) =>

--- a/tests/core/Statiq.Core.Tests/Modules/Control/ReplaceDocumentsFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/ReplaceDocumentsFixture.cs
@@ -36,8 +36,8 @@ namespace Statiq.Core.Tests.Modules.Control
                 await engine.ExecuteAsync(cancellationTokenSource.Token);
 
                 // Then
-                Assert.AreEqual(4, content.Count);
-                CollectionAssert.AreEquivalent(new[] { "A", "B", "C", "D" }, content);
+                Assert.That(content, Has.Count.EqualTo(4));
+                Assert.That(content, Is.EquivalentTo(new[] { "A", "B", "C", "D" }));
             }
 
             [Test]
@@ -63,8 +63,8 @@ namespace Statiq.Core.Tests.Modules.Control
                 await engine.ExecuteAsync(cancellationTokenSource.Token);
 
                 // Then
-                Assert.AreEqual(6, content.Count);
-                CollectionAssert.AreEquivalent(new[] { "A", "B", "C", "D", "G", "H" }, content);
+                Assert.That(content, Has.Count.EqualTo(6));
+                Assert.That(content, Is.EquivalentTo(new[] { "A", "B", "C", "D", "G", "H" }));
             }
 
             [Test]
@@ -90,8 +90,8 @@ namespace Statiq.Core.Tests.Modules.Control
                 await engine.ExecuteAsync(cancellationTokenSource.Token);
 
                 // Then
-                Assert.AreEqual(6, content.Count);
-                CollectionAssert.AreEquivalent(new[] { "G", "H", "A", "B", "C", "D" }, content);
+                Assert.That(content, Has.Count.EqualTo(6));
+                Assert.That(content, Is.EquivalentTo(new[] { "G", "H", "A", "B", "C", "D" }));
             }
         }
     }

--- a/tests/core/Statiq.Core.Tests/Modules/Extensibility/ExecuteConfigFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Extensibility/ExecuteConfigFixture.cs
@@ -40,7 +40,7 @@ namespace Statiq.Core.Tests.Modules.Extensibility
                 IReadOnlyList<TestDocument> outputs = await ExecuteAsync(inputs, execute);
 
                 // Then
-                CollectionAssert.AreEqual(inputs, outputs);
+                Assert.That(outputs, Is.EqualTo(inputs).AsCollection);
             }
 
             [Test]
@@ -156,7 +156,7 @@ namespace Statiq.Core.Tests.Modules.Extensibility
                 IReadOnlyList<TestDocument> outputs = await ExecuteAsync(inputs, execute);
 
                 // Then
-                CollectionAssert.AreEqual(inputs, outputs);
+                Assert.That(outputs, Is.EqualTo(inputs).AsCollection);
             }
 
             [Test]
@@ -174,7 +174,7 @@ namespace Statiq.Core.Tests.Modules.Extensibility
                 IReadOnlyList<TestDocument> result = await ExecuteAsync(count, execute);
 
                 // Then
-                CollectionAssert.AreEquivalent(document, result.Single());
+                Assert.That(result.Single(), Is.EquivalentTo(document));
             }
 
             [Test]

--- a/tests/core/Statiq.Core.Tests/Modules/IO/CopyFilesFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/IO/CopyFilesFixture.cs
@@ -41,12 +41,15 @@ namespace Statiq.Core.Tests.Modules.IO
                 await ExecuteAsync(context, copyFiles);
 
                 // Then
-                Assert.IsTrue(context.FileSystem.GetOutputFile("test-a.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputFile("test-b.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputDirectory("Subfolder").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("markdown-x.md").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.FileSystem.GetOutputFile("test-a.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("test-b.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputDirectory("Subfolder").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("markdown-x.md").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists, Is.False);
+                });
             }
 
             [Test]
@@ -60,12 +63,15 @@ namespace Statiq.Core.Tests.Modules.IO
                 await ExecuteAsync(context, copyFiles);
 
                 // Then
-                Assert.IsTrue(context.FileSystem.GetOutputFile("test-a.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputFile("test-b.txt").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputDirectory("Subfolder").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("markdown-x.md").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.FileSystem.GetOutputFile("test-a.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("test-b.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputDirectory("Subfolder").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("markdown-x.md").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists, Is.False);
+                });
             }
 
             [Test]
@@ -79,12 +85,15 @@ namespace Statiq.Core.Tests.Modules.IO
                 await ExecuteAsync(context, copyFiles);
 
                 // Then
-                Assert.IsFalse(context.FileSystem.GetOutputFile("test-a.txt").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("test-b.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputDirectory("Subfolder").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("markdown-x.md").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.FileSystem.GetOutputFile("test-a.txt").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("test-b.txt").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputDirectory("Subfolder").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("markdown-x.md").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists, Is.False);
+                });
             }
 
             [Test]
@@ -98,13 +107,16 @@ namespace Statiq.Core.Tests.Modules.IO
                 await ExecuteAsync(context, copyFiles);
 
                 // Then
-                Assert.IsFalse(context.FileSystem.GetOutputFile("test-a.txt").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("test-b.txt").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputDirectory("Subfolder").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("markdown-x.md").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("test-above-input.txt").Exists);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.FileSystem.GetOutputFile("test-a.txt").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("test-b.txt").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputDirectory("Subfolder").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("markdown-x.md").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("test-above-input.txt").Exists, Is.False);
+                });
             }
 
             [Test]
@@ -118,13 +130,16 @@ namespace Statiq.Core.Tests.Modules.IO
                 await ExecuteAsync(context, copyFiles);
 
                 // Then
-                Assert.IsTrue(context.FileSystem.GetOutputFile("test-a.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputFile("test-b.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputDirectory("Subfolder").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("markdown-x.md").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("test-above-input.txt").Exists); // Files outside an input path will not be copied
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.FileSystem.GetOutputFile("test-a.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("test-b.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputDirectory("Subfolder").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("markdown-x.md").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("test-above-input.txt").Exists, Is.False); // Files outside an input path will not be copied
+                });
             }
 
             [Test]
@@ -138,12 +153,15 @@ namespace Statiq.Core.Tests.Modules.IO
                 await ExecuteAsync(context, copyFiles);
 
                 // Then
-                Assert.IsTrue(context.FileSystem.GetOutputFile("test-a.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputFile("test-b.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists);
-                Assert.IsTrue(context.FileSystem.GetOutputDirectory("Subfolder").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("markdown-x.md").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.FileSystem.GetOutputFile("test-a.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("test-b.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputDirectory("Subfolder").Exists, Is.True);
+                    Assert.That(context.FileSystem.GetOutputFile("markdown-x.md").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists, Is.False);
+                });
             }
 
             [Test]
@@ -157,12 +175,15 @@ namespace Statiq.Core.Tests.Modules.IO
                 await ExecuteAsync(context, copyFiles);
 
                 // Then
-                Assert.IsFalse(context.FileSystem.GetOutputFile("test-a.txt").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("test-b.txt").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputDirectory("Subfolder").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("markdown-x.md").Exists);
-                Assert.IsFalse(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.FileSystem.GetOutputFile("test-a.txt").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("test-b.txt").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/test-c.txt").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputDirectory("Subfolder").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("markdown-x.md").Exists, Is.False);
+                    Assert.That(context.FileSystem.GetOutputFile("Subfolder/markdown-y.md").Exists, Is.False);
+                });
             }
 
             public async Task ShouldSetSourceAndDestination()

--- a/tests/core/Statiq.Core.Tests/Modules/IO/ReadWebFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/IO/ReadWebFixture.cs
@@ -41,14 +41,17 @@ namespace Statiq.Core.Tests.Modules.IO
                 // Then
                 Dictionary<string, string> headers = result[Keys.SourceHeaders] as Dictionary<string, string>;
 
-                Assert.IsNotNull(headers, "Header cannot be null");
-                Assert.IsTrue(headers.Count > 0, "Headers must contain contents");
-
-                foreach (KeyValuePair<string, string> h in headers)
+                Assert.Multiple(() =>
                 {
-                    Assert.IsNotEmpty(h.Key, "Header key cannot be empty");
-                    Assert.IsNotEmpty(h.Value, "Header value cannot be empty");
-                }
+                    Assert.That(headers, Is.Not.Null, "Header cannot be null");
+                    Assert.That(headers, Is.Not.Empty, "Headers must contain contents");
+
+                    foreach (KeyValuePair<string, string> h in headers)
+                    {
+                            Assert.That(h.Key, Is.Not.Empty, "Header key cannot be empty");
+                            Assert.That(h.Value, Is.Not.Empty, "Header value cannot be empty");
+                    }
+                });
 
                 result.Content.ShouldNotBeEmpty();
             }
@@ -81,14 +84,17 @@ namespace Statiq.Core.Tests.Modules.IO
                 {
                     Dictionary<string, string> headers = result[Keys.SourceHeaders] as Dictionary<string, string>;
 
-                    Assert.IsNotNull(headers, "Header cannot be null");
-                    Assert.IsTrue(headers.Count > 0, "Headers must contain contents");
-
-                    foreach (KeyValuePair<string, string> h in headers)
+                    Assert.Multiple(() =>
                     {
-                        Assert.IsNotEmpty(h.Key, "Header key cannot be empty");
-                        Assert.IsNotEmpty(h.Value, "Header value cannot be empty");
-                    }
+                        Assert.That(headers, Is.Not.Null, "Header cannot be null");
+                        Assert.That(headers, Is.Not.Empty, "Headers must contain contents");
+
+                        foreach (KeyValuePair<string, string> h in headers)
+                        {
+                                Assert.That(h.Key, Is.Not.Empty, "Header key cannot be empty");
+                                Assert.That(h.Value, Is.Not.Empty, "Header value cannot be empty");
+                        }
+                    });
 
                     result.Content.ShouldNotBeEmpty();
                 }

--- a/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
+++ b/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
@@ -3,11 +3,6 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Common\Statiq.Common.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Core\Statiq.Core.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
+++ b/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
@@ -4,7 +4,10 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Core\Statiq.Core.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
+++ b/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
@@ -3,6 +3,6 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Common\Statiq.Common.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Core\Statiq.Core.csproj" />
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
   </ItemGroup>
 </Project>

--- a/tests/core/TestConsoleApp/TestConsoleApp.csproj
+++ b/tests/core/TestConsoleApp/TestConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/tests/core/TestConsoleApp/TestConsoleApp.csproj
+++ b/tests/core/TestConsoleApp/TestConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/tests/extensions/Statiq.CodeAnalysis.Tests/AnalyzeCSharpTypesFixture.cs
+++ b/tests/extensions/Statiq.CodeAnalysis.Tests/AnalyzeCSharpTypesFixture.cs
@@ -435,7 +435,11 @@ namespace Statiq.CodeAnalysis.Tests
                 // Then
                 results.Single(x => x["Name"].Equals("Green"))["SpecificKind"].ShouldBe("Class");
                 results.Single(x => x["Name"].Equals("Blue"))["SpecificKind"].ShouldBe("Class");
+#if NET8_0_OR_GREATER
                 results.Single(x => x["Name"].Equals("Red"))["SpecificKind"].ShouldBe("Struct");
+#else
+                results.Single(x => x["Name"].Equals("Red"))["SpecificKind"].ShouldBe("Structure");
+#endif
                 results.Single(x => x["Name"].Equals("Yellow"))["SpecificKind"].ShouldBe("Enum");
             }
 

--- a/tests/extensions/Statiq.CodeAnalysis.Tests/AnalyzeCSharpTypesFixture.cs
+++ b/tests/extensions/Statiq.CodeAnalysis.Tests/AnalyzeCSharpTypesFixture.cs
@@ -435,7 +435,7 @@ namespace Statiq.CodeAnalysis.Tests
                 // Then
                 results.Single(x => x["Name"].Equals("Green"))["SpecificKind"].ShouldBe("Class");
                 results.Single(x => x["Name"].Equals("Blue"))["SpecificKind"].ShouldBe("Class");
-                results.Single(x => x["Name"].Equals("Red"))["SpecificKind"].ShouldBe("Structure");
+                results.Single(x => x["Name"].Equals("Red"))["SpecificKind"].ShouldBe("Struct");
                 results.Single(x => x["Name"].Equals("Yellow"))["SpecificKind"].ShouldBe("Enum");
             }
 


### PR DESCRIPTION
- Add net6.0 and net8.0 moniker
- Update Microsoft.SourceLink.GitHub to 8.0.0
- Update SharpZipLib to 1.4.2
- Fix tests that can break on non en-US i.e. lunar indexes
- Update Microsoft.NET.Test.Sdk to ~~17.8.0~~ 17.9.0
- Update NUnit3TestAdapter to 4.5.0
- Update Microsoft.CodeAnalysis.CSharp.Scripting to 4.7.0
- Update Microsoft.CodeAnalysis.CSharp to 4.7.0
- Update System.Collections.Immutable to 7.0.0
- Address breaking change in code analysis
- Drop netcoreapp3.1, dropped by transient dependencies i.e. System.Reflection.MetaData, System.Text.Encoding, etc.
- Update Microsoft.Extensions.* to 6.0.x & 8.0.0
- Update Microsoft.AspNetCore.* to 6.0.25 (8.0.0)
- Update Microsoft.IO.RecyclableMemoryStream to 2.3.2
- Update Microsoft.Data.SqlClient to ~~5.1.2~~ 5.1.5
- Update NUnit to ~~3.14.0~~ 4.0.1
- Update Shouldly to 4.2.1